### PR TITLE
fix: detect theme mode without an external `stty` (OpenWrt / busybox)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@
   container, and on GitHub CI (which uploads the
   [vhs](https://github.com/charmbracelet/vhs) previews as artifacts)
 
+### Fix
+
+- theme mode detection no longer depends on an external `stty`: on a system
+  without one (busybox built without the applet — e.g. **OpenWrt** routers —
+  or a tty `stty -g` can't read) it used to silently skip the OSC 11 query
+  and always fall back to dark; now a builtin-only collector runs the same
+  query synchronously at the first prompt (`read -s -d`, no subprocess), so
+  a light terminal is detected there too — over SSH from iTerm2 included
+
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -408,6 +408,12 @@ Notes:
   at startup — so the reply is never echoed to the screen; keystrokes typed
   before the first prompt are carefully separated from the reply and
   **replayed**, not eaten. The per-prompt render path stays subprocess-free.
+- No `stty` at all (busybox builds without the applet — e.g. **OpenWrt**
+  routers — or minimal containers)? Detection still works: the query then runs
+  synchronously at the first prompt with nothing but the `read` builtin, which
+  switches the tty by itself. Same result; the first prompt just pays one
+  terminal round-trip (still capped by the budget) instead of overlapping it
+  with `~/.zshrc`.
 - Because it asks the **terminal emulator** (not the OS), it works the same when
   running over **SSH** or **inside a Docker container** — the query reaches the
   real terminal at the far end of the pty.

--- a/dev/README.md
+++ b/dev/README.md
@@ -48,7 +48,10 @@ shells doing env checks only, the palette-migration once-guard, and
 terminal emulator: light/dark, both reply terminators (ST / BEL), an
 OSC-11-less terminal (DA1 sentinel, no wait), a silent terminal (bounded by
 the env-preset timeout), and laggy links — asserting the mode, zero input
-leak, and the timing invariants.
+leak, and the timing invariants. The whole matrix runs a second time with
+`stty` hidden from `PATH` (`nostty-*` kinds, plus payloads full of `c` hex
+digits), which forces the builtin-only `read` collector that busybox systems
+without the applet (OpenWrt) end up on.
 
 `integration/session-test.py` goes one level up and drives **full interactive
 sessions** (`zsh -i` + the theme loaded from ZDOTDIR), one scenario per
@@ -62,7 +65,9 @@ while a slow one joins via rerender, a mute terminal + a slow git together
 still cost ONE budget (waits share the deadline, they never stack), the
 dev-env segment carries palette colors on the very first paint (workers bake
 palette tokens, resolved at compose time), a non-interactive shell does env
-checks only, and COLORFGBG / preset send no query at all.
+checks only, COLORFGBG / preset send no query at all, and — with `stty`
+absent from `PATH` — the builtin collector still resolves the mode on the
+first paint, arms the late-reply guard, and replays typeahead.
 
 ```sh
 python3 dev/integration/osc-pty-test.py jovial.zsh-theme                  # whole matrix

--- a/dev/integration/osc-pty-test.py
+++ b/dev/integration/osc-pty-test.py
@@ -7,11 +7,17 @@
 # shell input, and that detection finishes via the DA1 sentinel (not by burning the
 # whole timeout) -- which is what makes it correct over high-latency SSH.
 #
+# The same matrix runs twice: once on the normal path (stty-driven tty switch,
+# `sysread` harvest) and once with `stty` hidden from PATH (`nostty-*` kinds),
+# which forces the builtin-only fallback collector (`read -s -d c` chain) that
+# busybox systems without the stty applet -- OpenWrt routers -- end up on.
+#
 # Usage:
 #   python3 osc-pty-test.py <theme_file>              # run the whole matrix
 #   python3 osc-pty-test.py <theme_file> <reply_kind> # run one scenario
 #     reply_kind: light-st | dark-st | light-bel | dark-bel
 #               | unsupported | silent | laggy-dark | laggy-light
+#               | nostty-<any of the above> | nostty-lightc-st | nostty-darkc-bel
 
 import os, pty, sys, select, time
 
@@ -21,6 +27,12 @@ ALL_KINDS = [
     "unsupported",   # DA1 answered but OSC 11 ignored -> falls back, fast (no wait)
     "silent",        # nothing answered -> falls back after the full deadline
     "laggy-dark", "laggy-light",  # weak-network SSH: reply delayed but still detected
+    # no `stty` in PATH -> the builtin-only collector must give the same answers
+    "nostty-light-st", "nostty-dark-st", "nostty-light-bel", "nostty-dark-bel",
+    "nostty-unsupported", "nostty-silent", "nostty-laggy-dark", "nostty-laggy-light",
+    # payloads full of `c` hex digits: the fallback reads stop at every `c`
+    # (the DA1 sentinel's final byte) and must chain on until the sentinel
+    "nostty-lightc-st", "nostty-darkc-bel",
 ]
 
 # deliberately FAR from the built-in default (0.3): the env preset must be
@@ -37,6 +49,9 @@ if len(sys.argv) <= 2:
     sys.exit(1 if rc else 0)
 
 kind = sys.argv[2]
+nostty = kind.startswith("nostty-")
+if nostty:
+    kind = kind[len("nostty-"):]
 
 ESC = b"\x1b"
 BEL = b"\x07"
@@ -46,6 +61,8 @@ DA1_REPLY = ESC + b"[?1;2c"   # a typical Device Attributes response (CSI ? 1 ; 
 COLORS = {
     "light": b"fafa/fafa/fafa",   # near-white -> light
     "dark":  b"1e1e/1f1f/2828",   # near-black -> dark
+    "lightc": b"cccc/cccc/cccc",  # light, every channel made of `c` digits
+    "darkc":  b"1c1c/2c2c/0c0c",  # dark, a `c` in every channel
 }
 
 # per-scenario terminal behavior: does it answer OSC 11 / DA1, with what tone /
@@ -72,11 +89,19 @@ def osc_reply(beh):
 # zsh script run on the slave side. time the detection, then drain any leftover
 # input in RAW mode and report how many stray bytes were pending (must be 0 = no
 # leak). RESULT_ELAPSED proves the DA1 sentinel short-circuits the wait.
+# with `nostty`, PATH is emptied around the detection call so `stty` cannot be
+# found (like a busybox without the applet), then restored for the leftover
+# check below; RESULT_STTY records what the theme saw
+hide_stty = 'saved_path=("${path[@]}"); path=(); hash -r' if nostty else ''
+show_stty = 'path=("${saved_path[@]}"); hash -r' if nostty else ''
 script = f"""
 source {theme}
+{hide_stty}
+print -r -- "RESULT_STTY=${{+commands[stty]}}"
 typeset -F start=$EPOCHREALTIME
 @jov.query-terminal-background
 typeset -F elapsed=$(( EPOCHREALTIME - start ))
+{show_stty}
 print -r -- "RESULT_MODE=${{JOVIAL_THEME_MODE}}"
 print -r -- "RESULT_ELAPSED=${{elapsed}}"
 leftover=''
@@ -141,12 +166,16 @@ def grab(key):
 mode = grab("RESULT_MODE")
 leftover = grab("RESULT_LEFTOVER")
 elapsed = grab("RESULT_ELAPSED")
+saw_stty = grab("RESULT_STTY")
 
 expect_mode = "" if kind in ("silent", "unsupported") else (
     kind.split("-")[1] if kind.startswith("laggy-") else kind.split("-")[0]
 )
+expect_mode = expect_mode.rstrip("c")     # lightc / darkc payloads resolve to light / dark
 ok_mode = (mode == expect_mode)
 ok_leak = (leftover == "0")
+# the fallback must really have been exercised: no stty visible to the theme
+ok_path = (saw_stty == ("0" if nostty else "1"))
 
 # timing invariant: only a terminal that ignores even DA1 (the "silent" case) may
 # wait out the full timeout. every other scenario -- including the laggy ones and
@@ -162,7 +191,8 @@ if kind == "silent":
 else:
     ok_time = (el is not None and el < DETECT_TIMEOUT * 0.9)
 
-status = "PASS" if (ok_mode and ok_leak and ok_time) else "FAIL"
-print(f"[{status}] kind={kind:12s} mode={mode!r} (expect {expect_mode!r}) "
-      f"leftover={leftover!r} elapsed={elapsed!r} ok_time={ok_time}")
+status = "PASS" if (ok_mode and ok_leak and ok_time and ok_path) else "FAIL"
+label = ("nostty-" if nostty else "") + kind
+print(f"[{status}] kind={label:19s} mode={mode!r} (expect {expect_mode!r}) "
+      f"leftover={leftover!r} elapsed={elapsed!r} ok_time={ok_time} stty={saw_stty!r}")
 sys.exit(0 if status == "PASS" else 1)

--- a/dev/integration/session-test.py
+++ b/dev/integration/session-test.py
@@ -36,6 +36,13 @@
 #                     no query bytes, no waiting
 #   colorfgbg-skip    conclusive COLORFGBG -> no query bytes sent at all
 #   preset-skip       preset JOVIAL_THEME_MODE -> no query bytes sent at all
+#   no-stty           no `stty` in PATH (busybox without the applet, e.g. an
+#                     OpenWrt router): the builtin-only collector still
+#                     resolves the mode on the first paint, no leak
+#   no-stty-late      no `stty` + reply slower than the budget: the zle guard
+#                     is armed on that path too -- swallowed, self-corrected
+#   no-stty-typeahead no `stty` + input typed before the first prompt: it is
+#                     separated from the reply and replayed, not eaten
 #
 # Command markers use `$((6*7))` so the *echoed input* (literal) can never
 # satisfy an assertion -- only real execution output ("...-42") can.
@@ -82,6 +89,17 @@ def make_slow_git(sleep_seconds):
                 f'exec {real_git} "$@"\n')
     os.chmod(shim, 0o755)
     return shim_dir
+
+
+def make_path_without_stty():
+    """a PATH made of one dir holding only what a session needs (zsh, git),
+    so `stty` -- and nothing else that could stand in for it -- is found"""
+    bin_dir = tempfile.mkdtemp(prefix='jovial-nostty-')
+    for name in ('zsh', 'git'):
+        real = shutil.which(name)
+        if real:
+            os.symlink(real, os.path.join(bin_dir, name))
+    return bin_dir
 
 
 def run_session(env=None, workdir=None, typeahead=None,
@@ -409,6 +427,59 @@ def scenario_preset_skip():
     return ok, f"query-sent={r['t_query'] is not None} mode-light={'MODE-light' in r['out']}"
 
 
+NO_STTY_PROBE = b'command -v stty >/dev/null 2>&1; echo "STTY-$((6*7))-$?"\r'
+
+
+def scenario_no_stty():
+    # `stty` unavailable (busybox without the applet, e.g. OpenWrt): the
+    # theme must not give up on detection -- the builtin `read` collector
+    # resolves the mode within the budget, and nothing leaks to the screen
+    r = run_session(tone='light',
+                    env={'PATH': make_path_without_stty()},
+                    commands=(NO_STTY_PROBE,
+                              b'echo "MODE-$JOVIAL_THEME_MODE"\r'))
+    out = r['out']
+    no_stty = 'STTY-42-1' in out
+    leaked = 'fafa' in out
+    within_budget = r['q2p'] is not None and r['q2p'] < 0.45
+    ok = no_stty and 'MODE-light' in out and not leaked and within_budget
+    return ok, (f"stty-absent={no_stty} mode-light={'MODE-light' in out} "
+                f"leaked={leaked} query->prompt={fmt(r['q2p'])}")
+
+
+def scenario_no_stty_late_reply():
+    # same as late-reply-guard, on the builtin path: the guard must be armed
+    # there too, so the late reply is swallowed and the palette self-corrects
+    r = run_session(lag=0.8, tone='light', settle=0.3,
+                    env={'PATH': make_path_without_stty()},
+                    commands=(b'echo "MODE1-$JOVIAL_THEME_MODE"\r',
+                              NO_STTY_PROBE,      # (after MODE1: keeps its timing)
+                              b'echo "MODE2-$JOVIAL_THEME_MODE"\r'))
+    out = r['out']
+    no_stty = 'STTY-42-1' in out
+    leaked = 'fafa' in out
+    ok = (no_stty and 'MODE1-dark' in out and 'MODE2-light' in out and not leaked)
+    return ok, (f"stty-absent={no_stty} fallback-first={'MODE1-dark' in out} "
+                f"self-corrected={'MODE2-light' in out} leaked={leaked}")
+
+
+def scenario_no_stty_typeahead():
+    # keystrokes typed while ~/.zshrc loads sit in the tty's canonical line
+    # buffer (no early tty switch without stty); the builtin collector reads
+    # them together with the reply -- they must be replayed, and the reply
+    # must still resolve
+    r = run_session(tone='light', typeahead=b'echo "TA-$((6*7))"\r',
+                    env={'PATH': make_path_without_stty()},
+                    commands=(NO_STTY_PROBE,
+                              b'echo "MODE-$JOVIAL_THEME_MODE"\r'))
+    out = r['out']
+    no_stty = 'STTY-42-1' in out
+    leaked = 'fafa' in out
+    ok = (no_stty and 'TA-42' in out and 'MODE-light' in out and not leaked)
+    return ok, (f"stty-absent={no_stty} typeahead-ran={'TA-42' in out} "
+                f"mode-light={'MODE-light' in out} leaked={leaked}")
+
+
 SCENARIOS = {
     'stderr-visible':    scenario_stderr_visible,
     'typeahead-replay':  scenario_typeahead_replay,
@@ -424,6 +495,9 @@ SCENARIOS = {
     'non-interactive':   scenario_non_interactive,
     'colorfgbg-skip':    scenario_colorfgbg_skip,
     'preset-skip':       scenario_preset_skip,
+    'no-stty':           scenario_no_stty,
+    'no-stty-late':      scenario_no_stty_late_reply,
+    'no-stty-typeahead': scenario_no_stty_typeahead,
 }
 
 

--- a/jovial.zsh-theme
+++ b/jovial.zsh-theme
@@ -302,6 +302,14 @@ typeset -gA JOVIAL_AFFIXES=(
 #      answers while the rest of `~/.zshrc` is still loading and the first
 #      prompt (almost) never waits on it.
 #
+# the overlapped send needs `stty` to switch the tty for the whole time the
+# reply may arrive. on a system without a usable `stty` (busybox builds
+# without the applet -- OpenWrt routers, minimal containers -- or a tty it
+# can't drive) the same query runs synchronously at first precmd instead,
+# with nothing but the `read` builtin (see `@jov.theme-query-builtin`): the
+# result is identical, the first prompt just pays one terminal round-trip
+# (still capped by the first paint budget).
+#
 # in a non-interactive / tty-less shell (scripts, pipelines) only the two env
 # checks above ever run -- nothing costly, no tty access, no subprocess.
 #
@@ -335,6 +343,10 @@ typeset -gi jovial_theme_query_inflight=0
 # harvest output: the mode resolved from the reply ('light' / 'dark' / '') and
 # any user keystrokes that arrived interleaved with it (see the replay widget)
 typeset -g jovial_theme_query_result='' jovial_theme_typeahead=''
+
+# the DA1 reply (CSI ... c) that ends the whole answer to the query; matched
+# on its parameter bytes so typed-ahead arrow keys (`ESC [ A`) can't fake it
+typeset -g jovial_theme_reply_end_regex=$'\e\\[[?0-9;]*c'
 
 # request a theme (re-)resolution at next precmd; re-sourcing the theme file
 # resets it to 1, so a re-source re-detects with fresh config
@@ -443,7 +455,7 @@ typeset -gi jovial_theme_detect_pending=1
         read -t 0.05 -k 1 key 2>/dev/null || break
         seq+="${key}"
         # the whole answer ends with the DA1 reply (CSI ... c)
-        [[ ${seq} =~ $'\e\\[[?0-9;]*c' ]] && break
+        [[ ${seq} =~ ${jovial_theme_reply_end_regex} ]] && break
     done
 
     @jov.theme-mode-from-osc-reply "${seq}" || return 0
@@ -515,8 +527,16 @@ typeset -gi jovial_theme_detect_pending=1
 # deliberately NOT `stty raw`: ISIG / OPOST stay on, so ^C keeps working and
 # output printed during the window still renders normally. `stty` (a few ms,
 # twice) is the only shell-out on this path -- never on per-prompt rendering.
+#
+# returns 1 -- with nothing sent and the tty untouched -- when the tty can't
+# be opened, or when there is no `stty` to switch it (or it can't drive this
+# tty): callers then fall back to `@jov.theme-query-builtin`.
 @jov.theme-query-send() {
     (( jovial_theme_query_inflight )) && return 0
+
+    # no external `stty` at all (busybox without the applet, e.g. OpenWrt):
+    # skip even the fork attempt, the builtin collector takes over at precmd
+    (( ${+commands[stty]} )) || return 1
 
     # the brace group keeps `2>/dev/null` scoped to this one open: a bare
     # `exec {fd}<>/dev/tty 2>/dev/null` would *permanently* redirect the
@@ -589,9 +609,8 @@ typeset -gi jovial_theme_detect_pending=1
                 break
             fi
             reply+="${chunk}"
-            # the DA1 reply (CSI ... c) marks the end of all answers; matched
-            # on its parameter bytes so typed-ahead arrow keys can't fake it
-            [[ ${reply} =~ $'\e\\[[?0-9;]*c' ]] && break
+            # the DA1 reply (CSI ... c) marks the end of all answers
+            [[ ${reply} =~ ${jovial_theme_reply_end_regex} ]] && break
         done
     } always {
         # restore the tty mode and close the fd no matter what -- even on an
@@ -603,7 +622,75 @@ typeset -gi jovial_theme_detect_pending=1
         add-zsh-hook -d zshexit @jov.theme-query-cleanup
     }
 
-    @jov.theme-split-reply "${reply}"
+    @jov.theme-reply-consume "${reply}"
+}
+
+# @jov.theme-query-builtin( $deadline )
+# fallback collector for a system without a usable `stty` (busybox built
+# without the applet -- OpenWrt routers, minimal containers -- or a tty that
+# `stty -g` can't read): the whole round-trip, send + collect, in one
+# synchronous step, using nothing but the `read` builtin.
+#
+#   $1 -- absolute deadline (`EPOCHREALTIME`-based) to wait for the reply
+#         to *start*; 0 (or absent) means take only what already arrived.
+#         same contract as `@jov.theme-query-harvest`.
+#
+# `read -s` (no echo) and `read -d` (non-canonical) switch the tty through
+# zsh's own termios calls, for exactly the duration of each `read`, which
+# also restores it by itself -- even on ^C or timeout -- so nothing external
+# is needed and the tty can never be left in a bad state.
+# the query rides as the `read` prompt string: `read` prints its prompt right
+# AFTER it turned echo off, so the reply can't possibly land while echo is
+# still on. each `read` returns at a `c` byte -- the final byte of the DA1
+# sentinel (`ESC [ ... c`) -- and the loop goes on until the whole sentinel
+# is in, since a `c` may also occur as a hex digit inside the color payload.
+#
+# without `stty` the tty can't be switched at theme source time, so the early
+# overlapped send is off the table: the first prompt pays one full terminal
+# round-trip here, capped by the deadline; a reply landing later than that is
+# handled by the zle guard, as usual.
+@jov.theme-query-builtin() {
+    local -F deadline=${1:-0}
+
+    jovial_theme_query_result=''
+    jovial_theme_typeahead=''
+
+    @jov.theme-guard-bind
+
+    local reply='' chunk=''
+    local -F remaining=0
+    local -i guard=0
+    # keep every byte verbatim: with a non-empty IFS `read` would strip the
+    # leading / trailing whitespace of each chunk (typed-ahead spaces / Enter)
+    local IFS=
+    # OSC 11 (ST terminated), then the DA1 sentinel; sent by the first `read`
+    # as its prompt (see above), the reads after it just collect the rest
+    local prompt=$'\e]11;?\e\\\e[c'
+
+    while (( guard++ < 64 )); do
+        remaining=$(( deadline - EPOCHREALTIME ))
+        (( remaining > 0 )) || remaining=0
+        chunk=''
+        # `-t` caps only the wait for the first byte of each read; once the
+        # answer started arriving, the read blocks up to its `c` -- the same
+        # grace a half-arrived reply gets in `@jov.theme-query-harvest`.
+        # (no stderr redirect here: in a non-interactive shell `read` prints
+        # its prompt -- our query -- to stderr rather than the shell's tty)
+        read -rs -d c -t ${remaining} "chunk?${prompt}" || break
+        prompt=''
+        reply+="${chunk}c"
+        [[ ${reply} =~ ${jovial_theme_reply_end_regex} ]] && break
+    done
+
+    @jov.theme-reply-consume "${reply}"
+}
+
+# @jov.theme-reply-consume( $collected_bytes )
+# common tail of both collectors: split what was read into the terminal
+# replies and the keystrokes typed ahead of them, schedule those keystrokes
+# to be replayed into the line editor, and report whether a mode came out
+@jov.theme-reply-consume() {
+    @jov.theme-split-reply "$1"
 
     # give back any keystrokes that were typed ahead of the reply
     if [[ -n ${jovial_theme_typeahead} && -o zle ]]; then
@@ -620,8 +707,12 @@ typeset -gi jovial_theme_detect_pending=1
 # for direct use / tests); the normal startup path splits send and harvest
 # apart to overlap the round-trip with `~/.zshrc` (see `@jov.theme-detect`).
 @jov.query-terminal-background() {
-    (( jovial_theme_query_inflight )) || @jov.theme-query-send || return 1
-    @jov.theme-query-harvest $(( EPOCHREALTIME + JOVIAL_THEME_DETECT_TIMEOUT )) || return 1
+    if (( jovial_theme_query_inflight )) || @jov.theme-query-send; then
+        @jov.theme-query-harvest $(( EPOCHREALTIME + JOVIAL_THEME_DETECT_TIMEOUT )) || return 1
+    else
+        # nothing could be sent ahead (no usable `stty`): builtin round-trip
+        @jov.theme-query-builtin $(( EPOCHREALTIME + JOVIAL_THEME_DETECT_TIMEOUT )) || return 1
+    fi
     JOVIAL_THEME_MODE="${jovial_theme_query_result}"
 }
 
@@ -679,11 +770,15 @@ typeset -gi jovial_theme_detect_pending=1
     [[ -o interactive && -t 0 && -t 1 ]] || return 0
 
     # start the query now if source time couldn't (e.g. the theme was loaded
-    # by a deferred plugin manager while the line editor was already active)
-    (( jovial_theme_query_inflight )) || @jov.theme-query-send || return 0
-
-    # harvest -- this also restores the tty and recovers typeahead
-    @jov.theme-query-harvest ${deadline}
+    # by a deferred plugin manager while the line editor was already active),
+    # then harvest -- this also restores the tty and recovers typeahead.
+    # without a usable `stty` nothing was (or can be) sent ahead of time: run
+    # the whole round-trip right here with the builtin-only collector instead
+    if (( jovial_theme_query_inflight )) || @jov.theme-query-send; then
+        @jov.theme-query-harvest ${deadline}
+    else
+        @jov.theme-query-builtin ${deadline}
+    fi
 
     if [[ -n ${jovial_theme_query_result} ]]; then
         JOVIAL_THEME_MODE="${jovial_theme_query_result}"


### PR DESCRIPTION
## What

On a system without `stty` — busybox built without the applet, e.g. **OpenWrt** routers (`busybox stty` → `applet not found`, no `coreutils-stty`) — the theme mode detection silently gave up and always fell back to **dark**, even when ssh-ing in from a light iTerm2. `COLORFGBG` is not forwarded over ssh, so the OSC 11 query is the only source there, and that query was never sent: `@jov.theme-query-send` needs `stty -g` to snapshot / switch the tty, failed, and returned 1.

This PR adds a **builtin-only fallback collector** so detection works without any external command; the `stty` path stays the primary one.

## How

- `@jov.theme-query-send` bails out early when `stty` is not in `commands` (or `stty -g` can't read the tty) — nothing sent, tty untouched; that return value now means "fall back".
- New `@jov.theme-query-builtin`: runs the same OSC 11 + DA1 query synchronously at first precmd using nothing but the `read` builtin.
  - `read -s` (echo off) + `read -d c` (non-canonical) switch the tty through zsh's own termios calls for the duration of each read, and `read` restores it by itself — even on ^C / timeout — so no `zshexit` cleanup hook is needed on this path.
  - the query rides as the `read` **prompt string**: zsh prints its prompt right *after* it turned echo off, so the reply can never land while echo is on (a `print` + `read` pair would leave a µs window).
  - reads stop at every `c` — the final byte of the DA1 sentinel (`ESC [ ... c`) — and chain on until the whole sentinel is in, since `c` may also be a hex digit inside the color payload (`rgb:1c1c/...`); `IFS=` keeps typed-ahead bytes verbatim.
- `@jov.theme-detect` / `@jov.query-terminal-background` fall back to the builtin collector when the send fails; reply splitting, typeahead replay and the late-reply zle guard are shared via the new `@jov.theme-reply-consume`, and the DA1 regex lives in one place (`jovial_theme_reply_end_regex`).

Trade-off: without `stty` the tty can't be switched at theme source time, so the early overlapped send is off the table — the first prompt pays one terminal round-trip (still capped by `JOVIAL_THEME_DETECT_TIMEOUT`, late replies handled by the zle guard as usual). With `stty` present nothing changes.

Known edge: `read -d c` blocks up to the next `c` once the answer started; a terminal answering OSC 11 but not DA1 would wait for a typed `c`. Every common terminal checked (xterm, iTerm2, Terminal.app, kitty, alacritty, wezterm, foot, VTE, xterm.js, tmux, mosh, Windows Terminal, Emacs term) answers DA1.

## Tests

- `dev/integration/osc-pty-test.py`: the whole matrix runs a second time with `stty` hidden from `PATH` (`nostty-*` kinds), plus `c`-heavy payloads (`cccc/cccc/cccc`, `1c1c/2c2c/0c0c`); mode / zero-leak / timing asserted, and `RESULT_STTY` proves the fallback was really exercised.
- `dev/integration/session-test.py`: `no-stty` (mode resolved on the first paint, within budget), `no-stty-late` (guard armed on that path: swallowed + self-corrected), `no-stty-typeahead` (typed-ahead input replayed, not eaten).
- Docs: README note, `dev/README.md`, CHANGELOG (Fix under v2.6.0, not tagged yet).

## Verification

- `task test` all green locally (macOS).
- Real OpenWrt 21.02 host (GL-MT6000, zsh 5.8, no `stty`), zinit checkout switched to this branch, real `~/.zshrc`, zpty playing a light terminal: first paint already uses the light palette, `JOVIAL_THEME_MODE=light`, query→prompt ~45 ms, no reply leak; with the reply delayed 0.8 s: dark first, budget-capped at ~350 ms, then repainted light by the guard. Confirmed by the reporter over a live iTerm2 (light) ssh session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFqFYKZJQbUBaxbQCEPjh7
